### PR TITLE
Quick Scintilla Lookup BugFix & Code Vault Updates

### DIFF
--- a/Code Vault.ahk
+++ b/Code Vault.ahk
@@ -2,8 +2,8 @@ Code_Vault(){
 	static ev,mainfile,newwin
 	v.lastsc:=csc(),mainfile:=ssn(current(1),"@file").text
 	newwin:=new windowtracker(19)
-	newwin.Add(["ListView,w100 h400 AltSubmit gdisplayvault Section,Code,h","Button,xm gaddcode,Add Code,y","Button,x+10 ginsertcode Default,Insert Into Segment,y","Button,x+10 gcreatenewsegment,Create New Segment,y","Button,x+10 gremovevaultentry,Remove Selected Entries,y"])
-	v.codevault:=new s(19,{pos:"xs+110 ys w600 h400"}),csc({hwnd:v.codevault.sc})
+	newwin.Add(["ListView,w200 h400 AltSubmit gdisplayvault Section,Code,h","Button,xm gaddcode,Add Code,y","Button,x+10 ginsertcode Default,Insert Into Segment,y","Button,x+10 gcreatenewsegment,Create New Segment,y","Button,x+10 gremovevaultentry,Remove Selected Entries,y"])
+	v.codevault:=new s(19,{pos:"xs+210 ys w600 h400"}),csc({hwnd:v.codevault.sc})
 	newwin.resize.Insert({control:v.codevault.sc,pos:"wh"})
 	sc:=csc(),sc.2171(1),bracesetup(19),hotkeys([19],{esc:"19GuiClose"})
 	newwin.Show("Code Vault")
@@ -18,7 +18,8 @@ Code_Vault(){
 	return
 	createnewsegment:
 	SplitPath,mainfile,,cdir
-	file:=InputBox(csc().sc,"New Segment","Enter a name for this new file","")
+	ControlGet,defName,List,Selected,SysListView321,% hwnd([19])
+	file:=InputBox(csc().sc,"New Segment","Enter a name for this new file",RegExReplace(defName,"_"," "))
 	if ErrorLevel
 		return
 	file:=!InStr(file,".ahk")?file ".ahk":file

--- a/notify.ahk
+++ b/notify.ahk
@@ -37,7 +37,7 @@ notify(csc=""){
 			command:=StrGet(fn.text,"utf-8")
 			info:=scintilla.ssn("//commands/item[@name='" command "']")
 			ea:=xml.ea(info),start:=sc.2266(sc.2008,1),end:=sc.2267(sc.2008,1)
-			syn:=ea.syntax "()"?ea.code:ea.code,sc.2160(start,end),sc.2170(0,[syn])
+			syn:=ea.syntax?ea.code "()":ea.code,sc.2160(start,end),sc.2170(0,[syn])
 			if ea.syntax
 				sc.2025(sc.2008-1),sc.2200(start,ea.code ea.syntax)
 		}Else if(fn.listType=2){


### PR DESCRIPTION
- Fixed bug in 'Quick Scintilla Code Lookup' that was placing caret in wrong position & not inserting the "()" after the function name. See commit 7f39f4c.
- Minor modification to Code Vault, adding a convinience feature and making the GUI more usable. See commit 9faa11b.