### PR TITLE
Cut/Copy Entire Line

### DIFF
--- a/copy.ahk
+++ b/copy.ahk
@@ -1,6 +1,11 @@
 copy(){
 	copy:
-	Clipboard:=RegExReplace(csc().getseltext(),"\n","`r`n")
+	sc:=csc()
+	if (!sc.getseltext())	;Can add a check for "Cut/Copy Line When Selection Emtpy" here
+		sc.2455
+	else
+		Send,^c
+	Clipboard:=RegExReplace(Clipboard,"\n","`r`n")
 	if(hwnd(30)){
 		WinActivate,% hwnd([30])
 		Sleep,50

--- a/cut.ahk
+++ b/cut.ahk
@@ -1,6 +1,10 @@
 cut(){
 	cut:
-	Send,^x
+	sc:=csc()
+	if (!sc.getseltext())	;Can check for "Copy/Cut Entire Line When Selection Empty" option here
+		sc.2337
+	else
+		Send,^x
 	Clipboard:=RegExReplace(Clipboard,"\n","`r`n")
 	return
 }


### PR DESCRIPTION
- Changed cut & copy commands to cut/copy entire contents of current line if nothing is selected.
- If you would like/prefer, these changes can be modified to check for an option that enables/disables this feature