### PR TITLE
Split Code to lib

### DIFF
--- a/Code Vault.ahk
+++ b/Code Vault.ahk
@@ -18,6 +18,7 @@ Code_Vault(){
 	return
 	createnewsegment:
 	SplitPath,mainfile,,cdir
+	cdir.="\lib"	;Can check for "Split Code to Lib Dir" option here
 	ControlGet,defName,List,Selected,SysListView321,% hwnd([19])
 	file:=InputBox(csc().sc,"New Segment","Enter a name for this new file",RegExReplace(defName,"_"," "))
 	if ErrorLevel

--- a/new segment.ahk
+++ b/new segment.ahk
@@ -15,7 +15,7 @@ new_segment(new:="",text:="",adjusted:=""){
 		return tv(ssn(node,"@tv").Text)
 	SplitPath,new,file,newdir,,function
 	Gui,1:Default
-	Relative:=relativepath(cur,new),func:=clean(func),current:=ssn(current(1),"@file").text
+	Relative:=RegExReplace(relativepath(cur,new),"i)^lib\\([^\\]+)\.ahk$","<$1>"),func:=clean(func),current:=ssn(current(1),"@file").text
 	SplitPath,current,,currentdir
 	obj:=NewFile(cur,new),select:=files.under(obj.obj,"file",{file:new,filename:file,include:Chr(35) "Include " Relative,tv:TV_Add(file,obj.tv,"Sort")}),update({file:new,text:text})
 	if(adjusted)

--- a/save.ahk
+++ b/save.ahk
@@ -34,6 +34,8 @@ save(option=""){
 			encoding:="UTF-16"
 		if(v.options.Force_UTF8)
 			encoding:="UTF-8"
+		if (!FileExist(dir))
+			FileCreateDir,%dir%
 		FileAppend,%text%,%filename%,%encoding%
 		Gui,1:TreeView,% hwnd("fe")
 		multi:=files.sn("//file[@file='" filename "']")

--- a/split code.ahk
+++ b/split code.ahk
@@ -38,6 +38,7 @@ split_code(){
 	split:
 	cfile:=current(3).file,dd:=current(2).file
 	SplitPath,dd,,outdir
+	outdir.="\lib"	;Can check for "Split Files to lib Folder" option here
 	editfile:=current(3).file
 	Gui,66:Default
 	while,LV_GetNext(){


### PR DESCRIPTION
**Updated:** Also changed the "Create New Segment" feature of the code vault to place new segments into \lib dir. Again, this could be enabled/disabled by simply checking a new option like "Split Code to Lib Folder" before appending "\lib" to the folder var.

This is a feature that I've been manually implementing myself for a while now, and thought it might be nice if it were included (at least as an option) in the release of Studio. Maybe others would also like the option to organize their code in this way? This pull request includes the following changes:
- The split code feature places newly created segment files into a \lib sub-directory within the script's main folder
- The "#Include " line in the main script uses #Include <Filename> notation for any segments created in the \lib sub-directory within the script's main folder
- This feature could be enabled/disabled via a new option such as "Split Code to Lib Folder"; simply check for this option before appending "\lib" to the **outdir** var in split_files.

Even if you decide not to include this option, the change in the save() function would be nice to include anyway (possibly coupled with an option) as it will use the #Include <filename> format anytime a segment is being created in a \lib subdir of the main script folder. Up to you.

Also, the one issue with this is that after splitting the files into a \lib folder, the project explorer shows a separate Lib tree item for each new file... this goes away after restarting Studio or re-opening the file. I messed with a couple of ways of dealing with this, including:
- Adding a save(), exit(1,1) after splitting the files to reload Studio
- Closing & re-opening the main split file using save(), close(), open(dd)
  I decided to leave this out and let you decided how/if you wanted to remedy this slight issue.
