### PR TITLE
Fixed: Abort exiting Studio if "Unsaved Changes" prompt is closed/canceled

### DIFF
--- a/exit.ahk
+++ b/exit.ahk
@@ -6,7 +6,10 @@ exit(x="",reload=0){
 		if file
 			settings.add({path:"last/file",text:file,dup:1})
 	}
-	toolbar.save(),rebar.save(),save(v.options.disable_autosave?1:0),menus.save(1),getpos()
+	toolbar.save(),rebar.save()
+	if (save(v.options.disable_autosave?1:0)="cancel")
+		return
+	menus.save(1),getpos()
 	settings.add({path:"gui",att:{zoom:csc().2374}}),settings.save(1),bookmarks.save(1)
 	for a in pluginclass.close
 		If WinExist("ahk_id" a)

--- a/save.ahk
+++ b/save.ahk
@@ -7,7 +7,7 @@ save(option=""){
 			IfMsgBox,No
 				info.2.Remove(a)
 			IfMsgBox,Cancel
-				return
+				return "cancel"
 		}
 	}
 	for filename in info.2{


### PR DESCRIPTION
When exiting Studio, if there are unsaved changes, the user is prompted whether or not the want to save the changes; currently, if the user dismisses or presses cancel on the MsgBox, Studio stops checking/saving files, but continues to exit.

-Fixed: Pressing 'Cancel' or closing the unsaved file changes message box now aborts exiting Studio