### PR TITLE
Make Run_As() slightly more robust

### DIFF
--- a/AHK-Studio.ahk
+++ b/AHK-Studio.ahk
@@ -11991,7 +11991,7 @@ Run_As(exe){
 	Save()
 	SplitPath,A_AhkPath,,dir
 	SplitPath,file,,fdir
-	Run,%dir%\%exe% "%file%",%fdir%,,pid
+	Run,"%dir%\%exe%.exe" "%file%",%fdir%,,pid
 	if(!IsObject(v.runpid))
 		v.runpid:=[]
 	v.runpid[pid]:=1


### PR DESCRIPTION
Adding quote marks and the filename extension eliminates ambiguity, which is important due to how CreateProcess parses the command line:

> The system tries to interpret the possibilities in the following order:
>  - c:\program.exe
>  - c:\program files\sub.exe
>  - c:\program files\sub dir\program.exe
>  - c:\program files\sub dir\program name.exe

If CreateProcess fails, Run relies on the the quote marks and/or filename extension to split the command line into "action" and "params", which are shown in the error message after attempting ShellExecuteEx; but that only matters if CreateProcess fails.

(In my case, the ambiguity was a red herring, and the root issue was that "Run As" simply doesn't work for untitled files that have not been saved.)